### PR TITLE
Support Phinx 0.5.0 insert() method.

### DIFF
--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -344,15 +344,14 @@ class CakeAdapter implements AdapterInterface
     }
 
     /**
-     * Inserts data into the table
+     * Inserts data into a table.
      *
      * @param Table $table where to insert data
-     * @param array $columns column names
-     * @param $data
+     * @param array $row
      */
-    public function insert(Table $table, $columns, $data)
+    public function insert(Table $table, $row)
     {
-        return $this->adapter->insert($table, $columns, $data);
+        return $this->adapter->insert($table, $row);
     }
 
     /**

--- a/src/CakeAdapter.php
+++ b/src/CakeAdapter.php
@@ -348,6 +348,7 @@ class CakeAdapter implements AdapterInterface
      *
      * @param Table $table where to insert data
      * @param array $row
+     * @return void
      */
     public function insert(Table $table, $row)
     {


### PR DESCRIPTION
Phinx 0.5.0 changes the `insert()` method signatures. A seperate columns array is no longer used.

The PR aligns CakePHP migrations with the upcoming breaking change.

For more information on the upcoming changes in Phinx 0.5.0, please see my PR: https://github.com/robmorgan/phinx/pull/693.

Cheers,

Rob
